### PR TITLE
fix: treating exception on dispose

### DIFF
--- a/src/Codibre.MSSqlSession/Impl/AsyncDbSession.cs
+++ b/src/Codibre.MSSqlSession/Impl/AsyncDbSession.cs
@@ -89,9 +89,12 @@ internal sealed class AsyncDbSession : IAsyncDbSession
     {
         var storage = _asyncStorage.Value;
         if (storage is null) return;
-        storage.Transaction?.Rollback();
-        storage.Connection?.Close();
-        storage.Connection?.Dispose();
+        if (storage.Transaction is not null) Helper.Try(() => storage.Transaction.Rollback());
+        if (storage.Connection is not null)
+        {
+            Helper.Try(() => storage.Connection.Close());
+            Helper.Try(() => storage.Connection.Dispose());
+        }
         _asyncStorage.Value = null;
     }
 

--- a/src/Codibre.MSSqlSession/Impl/Utils/Helper.cs
+++ b/src/Codibre.MSSqlSession/Impl/Utils/Helper.cs
@@ -1,0 +1,17 @@
+﻿namespace Codibre.MSSqlSession.Impl.Utils;
+
+internal static class Helper
+{
+    internal static bool Try(Action action)
+    {
+        try
+        {
+            action();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Exception on dispose must be ignored, because it may have been called due to another exception already, which is the one we want to throw to the final user